### PR TITLE
Add tests for search, saved searches and search results pages

### DIFF
--- a/frontend/src/routes/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/routes/SearchPage/SearchPage.test.tsx
@@ -1,8 +1,191 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { Router } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MockedProvider } from '@apollo/client/testing'
+import { GraphQLError } from 'graphql'
+import { wait } from '../../lib/test-helper'
 import SearchPage from './SearchPage'
+import { SavedSearchesDocument, SearchSchemaDocument, SearchCompleteDocument } from '../../search-sdk/search-sdk'
 
-test('renders search', () => {
-    const { getByText } = render(<SearchPage />)
-    expect(getByText('Search items')).toBeInTheDocument()
+describe('SearchPage', () => {
+    it('should render default search page correctly', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SavedSearchesDocument,
+                },
+                result: {
+                    data: {
+                        items: [
+                            {
+                                description: 'testSavedQueryDesc1',
+                                id: '1609811592984',
+                                name: 'testSavedQuery1',
+                                searchText: 'kind:pod',
+                                __typename: 'userSearch',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchSchemaDocument,
+                },
+                result: {
+                    data: {
+                        searchSchema: {
+                            allProperties: ['cluster', 'kind', 'label', 'name', 'namespace'],
+                        },
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchPage />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes - testing that saved searches card label is not present
+        expect(screen.getAllByText('Saved searches')[1]).toBeFalsy()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Open new search tab')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Saved searches')).toBeTruthy())
+    })
+
+    it('should render page with errors', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SavedSearchesDocument,
+                },
+                result: {
+                    data: {
+                        items: [
+                            {
+                                description: 'testSavedQueryDesc1',
+                                id: '1609811592984',
+                                name: 'testSavedQuery1',
+                                searchText: 'kind:pod',
+                                __typename: 'userSearch',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchSchemaDocument,
+                },
+                result: {
+                    data: {},
+                    errors: [new GraphQLError('Error getting search schema data')],
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchPage />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes - testing that saved searches card label is not present
+        expect(screen.getAllByText('Saved searches')[1]).toBeFalsy()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('An unexpected error occurred.')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('The search service is unavailable.')).toBeTruthy())
+    })
+
+    it('should render search page correctly and add a search', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SavedSearchesDocument,
+                },
+                result: {
+                    data: {
+                        items: [
+                            {
+                                description: 'testSavedQueryDesc1',
+                                id: '1609811592984',
+                                name: 'testSavedQuery1',
+                                searchText: 'kind:pod',
+                                __typename: 'userSearch',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchSchemaDocument,
+                },
+                result: {
+                    data: {
+                        searchSchema: {
+                            allProperties: ['cluster', 'kind', 'label', 'name', 'namespace'],
+                        },
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchCompleteDocument,
+                    variables: {
+                        property: 'kind',
+                        query: {
+                            filters: [],
+                            keywords: [],
+                        },
+                    },
+                },
+                result: {
+                    data: {
+                        searchComplete: ['cluster', 'pod', 'deployment'],
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchPage />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes - testing that saved searches card label is not present
+        expect(screen.getAllByText('Saved searches')[1]).toBeFalsy()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Open new search tab')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Saved searches')).toBeTruthy())
+
+        const searchbar = screen.getByText('Search items')
+        expect(searchbar).toBeTruthy()
+        userEvent.click(searchbar)
+        userEvent.type(searchbar, 'kind ')
+
+        // check if the three values are diplayed
+        await waitFor(() => expect(screen.queryByText('cluster')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('pod')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('deployment')).toBeTruthy())
+
+        // click on a value
+        const suggestionItem = screen.getByText('deployment')
+        expect(suggestionItem).toBeTruthy()
+        userEvent.click(suggestionItem)
+
+        // check searchbar updated properly
+        await waitFor(() => expect(screen.queryByText('kind:deployment')).toBeTruthy())
+    })
 })

--- a/frontend/src/routes/SearchPage/SearchPage.tsx
+++ b/frontend/src/routes/SearchPage/SearchPage.tsx
@@ -47,12 +47,6 @@ const useStyles = makeStyles({
 
 // Adds AcmAlert to page if there's errors from the Apollo queries.
 function HandleErrors(schemaError: ApolloError | undefined, completeError: ApolloError | undefined) {
-    if (schemaError) {
-        console.error('Search schema query error.', schemaError)
-    }
-    if (completeError) {
-        console.error('Search complete query error.', completeError)
-    }
     if (schemaError || completeError) {
         return (
             <div style={{ marginBottom: '1rem' }}>
@@ -79,7 +73,7 @@ function RenderSearchBar(props: {
     const toggle = () => toggleOpen(!open)
     const searchSchemaResults = useSearchSchemaQuery({
         skip: searchQuery.endsWith(':') || operators.some((operator: string) => searchQuery.endsWith(operator)),
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
     })
 
     const searchCompleteValue = getSearchCompleteString(searchQuery)
@@ -89,7 +83,7 @@ function RenderSearchBar(props: {
     })
     const searchCompleteResults = useSearchCompleteQuery({
         skip: !searchQuery.endsWith(':') && !operators.some((operator: string) => searchQuery.endsWith(operator)),
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
         variables: {
             property: searchCompleteValue,
             query: searchCompleteQuery,
@@ -155,7 +149,7 @@ function RenderDropDownAndNewTab(props: {
     const classes = useStyles()
 
     const { data } = useSavedSearchesQuery({
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
     })
 
     const queries = data?.items ?? ([] as UserSearch[])

--- a/frontend/src/routes/SearchPage/components/Modals/DeleteSearchModal.test.tsx
+++ b/frontend/src/routes/SearchPage/components/Modals/DeleteSearchModal.test.tsx
@@ -125,7 +125,6 @@ describe('DeleteSearchModal', () => {
         )
 
         // find the button and simulate a click
-        // const submitButton = screen.getByTestId('delete-saved-search-submit')
         const submitButton = screen.getByText('Delete')
         expect(submitButton).toBeTruthy()
         userEvent.click(submitButton)

--- a/frontend/src/routes/SearchPage/components/SavedSearchQueries.test.tsx
+++ b/frontend/src/routes/SearchPage/components/SavedSearchQueries.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { Router } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { wait } from '../../../lib/test-helper'
+import SavedSearchQueries from './SavedSearchQueries'
+import { SavedSearchesDocument, SearchResultCountDocument } from '../../../search-sdk/search-sdk'
+
+describe('SavedSearchQueries Page', () => {
+    it('should render page with correct data', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SavedSearchesDocument,
+                },
+                result: {
+                    data: {
+                        items: [
+                            {
+                                description: 'testSavedQueryDesc1',
+                                id: '1609811592984',
+                                name: 'testSavedQuery1',
+                                searchText: 'kind:pod',
+                                __typename: 'userSearch',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['daemonset', 'deployment', 'job', 'statefulset', 'replicaset'],
+                                    },
+                                ],
+                            },
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                    {
+                                        property: 'status',
+                                        values: [
+                                            'Pending',
+                                            'Error',
+                                            'Failed',
+                                            'Terminating',
+                                            'ImagePullBackOff',
+                                            'CrashLoopBackOff',
+                                            'RunContainerError',
+                                            'ContainerCreating',
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'created',
+                                        values: ['hour'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                count: 1,
+                                __typename: 'SearchResult',
+                            },
+                            {
+                                count: 2,
+                                __typename: 'SearchResult',
+                            },
+                            {
+                                count: 3,
+                                __typename: 'SearchResult',
+                            },
+                            {
+                                count: 4,
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SavedSearchQueries setSelectedSearch={() => {}} setCurrentQuery={() => {}} />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        expect(screen.queryByText('Suggested search templates')).not.toBeInTheDocument()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('testSavedQuery1')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('testSavedQueryDesc1')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Show all (1)')).toBeTruthy())
+    })
+})

--- a/frontend/src/routes/SearchPage/components/SearchResults.test.tsx
+++ b/frontend/src/routes/SearchPage/components/SearchResults.test.tsx
@@ -1,0 +1,515 @@
+import React from 'react'
+import { Router } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { GraphQLError } from 'graphql'
+import { wait } from '../../../lib/test-helper'
+import SearchResults from './SearchResults'
+import {
+    SearchResultItemsDocument,
+    SearchResultRelatedCountDocument,
+    SearchResultRelatedItemsDocument,
+} from '../../../search-sdk/search-sdk'
+
+describe('SearchResults Page', () => {
+    it('should render page with correct data from search WITH keyword', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SearchResultItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: ['testCluster'],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                items: [
+                                    {
+                                        apiversion: 'v1',
+                                        cluster: 'testCluster',
+                                        container: 'installer',
+                                        created: '2021-01-04T14:53:52Z',
+                                        hostIP: '10.0.128.203',
+                                        kind: 'pod',
+                                        name: 'testPod',
+                                        namespace: 'testNamespace',
+                                        podIP: '10.129.0.40',
+                                        restarts: 0,
+                                        startedAt: '2021-01-04T14:53:52Z',
+                                        status: 'Completed',
+                                        _uid: 'testing-search-results-pod',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchResults currentQuery={'kind:pod testCluster'} preSelectedRelatedResources={[]} />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        expect(screen.getByText('Loading')).toBeInTheDocument()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Pod (1)')).toBeTruthy())
+    })
+
+    it('should render page with correct data from search WITHOUT keyword', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SearchResultRelatedCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                related: [
+                                    {
+                                        kind: 'cluster',
+                                        count: 1,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'node',
+                                        count: 6,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'secret',
+                                        count: 203,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultRelatedCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                related: [
+                                    {
+                                        kind: 'cluster',
+                                        count: 1,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'node',
+                                        count: 6,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'secret',
+                                        count: 203,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                items: [
+                                    {
+                                        apiversion: 'v1',
+                                        cluster: 'testCluster',
+                                        container: 'installer',
+                                        created: '2021-01-04T14:53:52Z',
+                                        hostIP: '10.0.128.203',
+                                        kind: 'pod',
+                                        name: 'testPod',
+                                        namespace: 'testNamespace',
+                                        podIP: '10.129.0.40',
+                                        restarts: 0,
+                                        startedAt: '2021-01-04T14:53:52Z',
+                                        status: 'Completed',
+                                        _uid: 'testing-search-results-pod',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchResults currentQuery={'kind:pod'} preSelectedRelatedResources={[]} />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        expect(screen.getByText('Loading')).toBeInTheDocument()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Pod (1)')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Show all (3)')).toBeTruthy())
+    })
+
+    it('should render page with correct data from search WITHOUT keyword & preselected related resources', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SearchResultRelatedCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                related: [
+                                    {
+                                        kind: 'cluster',
+                                        count: 1,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'node',
+                                        count: 6,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'secret',
+                                        count: 203,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultRelatedCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                related: [
+                                    {
+                                        kind: 'cluster',
+                                        count: 1,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'node',
+                                        count: 6,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                    {
+                                        kind: 'secret',
+                                        count: 203,
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultRelatedItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                                relatedKinds: ['node'],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                related: [
+                                    {
+                                        kind: 'node',
+                                        items: [
+                                            {
+                                                apiversion: 'v1',
+                                                architecture: 'amd64',
+                                                cluster: 'testCluster',
+                                                cpu: 4,
+                                                created: '2021-01-04T14:42:49Z',
+                                                kind: 'node',
+                                                name: 'testNode',
+                                                osImage: 'Red Hat Enterprise Linux CoreOS 45.82.202008290529-0 (Ootpa)',
+                                                role: 'master',
+                                                _uid: 'testing-search-related-results-node',
+                                            },
+                                        ],
+                                        __typename: 'SearchRelatedResult',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                items: [
+                                    {
+                                        apiversion: 'v1',
+                                        cluster: 'testCluster',
+                                        container: 'installer',
+                                        created: '2021-01-04T14:53:52Z',
+                                        hostIP: '10.0.128.203',
+                                        kind: 'pod',
+                                        name: 'testPod',
+                                        namespace: 'testNamespace',
+                                        podIP: '10.129.0.40',
+                                        restarts: 0,
+                                        startedAt: '2021-01-04T14:53:52Z',
+                                        status: 'Completed',
+                                        _uid: 'testing-search-results-pod',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchResults currentQuery={'kind:pod'} preSelectedRelatedResources={['node']} />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        expect(screen.getAllByText('Loading')).toBeTruthy()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Pod (1)')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Show all (3)')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Related Node (1)')).toBeTruthy())
+    })
+
+    it('should render page with errors', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SearchResultRelatedCountDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {},
+                    errors: [new GraphQLError('Error getting related count data')],
+                },
+            },
+            {
+                request: {
+                    query: SearchResultRelatedItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                                relatedKinds: ['node'],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {},
+                    errors: [new GraphQLError('Error getting related items data')],
+                },
+            },
+            {
+                request: {
+                    query: SearchResultItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+                result: {
+                    data: {},
+                    errors: [new GraphQLError('Error getting search data')],
+                },
+            },
+        ]
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <SearchResults currentQuery={'kind:pod'} preSelectedRelatedResources={['node']} />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        expect(screen.getAllByText('Loading')).toBeTruthy()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('Error getting related count data')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Error getting related items data')).toBeTruthy())
+        await waitFor(() => expect(screen.queryByText('Error getting search data')).toBeTruthy())
+    })
+})

--- a/frontend/src/routes/SearchPage/components/SearchResults.tsx
+++ b/frontend/src/routes/SearchPage/components/SearchResults.tsx
@@ -33,7 +33,7 @@ function RenderRelatedTables(
     const queryFilters = convertStringToQuery(currentQuery)
     const { data, loading, error } = useSearchResultRelatedItemsQuery({
         skip: selectedKinds.length === 0 || queryFilters.keywords.length > 0,
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
         variables: {
             input: [{ ...convertStringToQuery(currentQuery), relatedKinds: selectedKinds }],
         },
@@ -119,9 +119,9 @@ function RenderRelatedTiles(
     const queryFilters = convertStringToQuery(currentQuery)
     const { data, error, loading } = useSearchResultRelatedCountQuery({
         skip: queryFilters.keywords.length > 0,
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
         variables: {
-            input: [convertStringToQuery(currentQuery)],
+            input: [queryFilters],
         },
     })
     if (loading) {
@@ -182,7 +182,7 @@ function RenderSearchTables(
     selectedRelatedKinds: string[]
 ) {
     const { data, error, loading } = useSearchResultItemsQuery({
-        client: searchClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
         variables: {
             input: [convertStringToQuery(currentQuery)],
         },


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

### Description of changes
Added tests for:
- Search page
- Search results page
- Saved search page

Overall coverage:
File                                 | % Stmts | % Branch | % Funcs | % Lines |
-------------------------------------|---------|----------|---------|---------|
All files                            |   53.89 |    59.14 |   38.22 |   53.69 |

