### PR TITLE
Rework the details page URL & fix console-api queries using selflink

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,29 @@ const SearchPage = lazy(() => import('./routes/SearchPage/SearchPage'))
 const DetailsPage = lazy(() => import('./routes/DetailsPage/DetailsPage'))
 const OverviewPage = lazy(() => import('./routes/Overview/OverviewPage'))
 
+// Function to handle deprecated selfLink in old multicloud/details url
+function getUrlParams() {
+    const baseSegments = window.location.pathname.split('/').slice(3)
+    if (baseSegments[baseSegments.length - 1] === 'logs') {
+        baseSegments.pop()
+    }
+    const cluster = baseSegments[0]
+    const name = baseSegments[baseSegments.length - 1]
+    const kind = baseSegments[baseSegments.length - 2]
+    const isNamespaced = baseSegments[baseSegments.length - 4] === 'namespaces'
+    const namespace = isNamespaced ? baseSegments[baseSegments.length - 3] : ''
+    const apiversion = isNamespaced
+        ? baseSegments.slice(1, baseSegments.indexOf('namespaces')).join('/')
+        : baseSegments.slice(1, baseSegments.indexOf(kind)).join('/')
+    let resourceUrlParams = '?'
+    resourceUrlParams = `${resourceUrlParams}${cluster !== '' ? `cluster=${cluster}` : ''}`
+    resourceUrlParams = `${resourceUrlParams}${kind !== '' ? `&kind=${kind}` : ''}`
+    resourceUrlParams = `${resourceUrlParams}${apiversion !== '' ? `&apiversion=${apiversion}` : ''}`
+    resourceUrlParams = `${resourceUrlParams}${namespace !== '' ? `&namespace=${namespace}` : ''}`
+    resourceUrlParams = `${resourceUrlParams}${name !== '' ? `&name=${name}` : ''}`
+    return resourceUrlParams
+}
+
 function App() {
     return (
         <Router>
@@ -23,7 +46,10 @@ function App() {
                 <Redirect from={'/multicloud/search'} to={{ pathname: '/search', search: window.location.search }} />
                 <Redirect
                     from={'/multicloud/details'}
-                    to={{ pathname: window.location.pathname.replace('/multicloud/details', '/resources') }}
+                    to={{
+                        pathname: '/resources',
+                        search: getUrlParams(),
+                    }}
                 />
 
                 {/* Redirect to base search page on all other paths */}

--- a/frontend/src/console-sdk/console-sdk.ts
+++ b/frontend/src/console-sdk/console-sdk.ts
@@ -206,6 +206,36 @@ export type CompliancePolicy = K8sObject & {
     message?: Maybe<Scalars['String']>
 }
 
+export type PolicyTemplates = {
+    apiVersion?: Maybe<Scalars['String']>
+    complianceType?: Maybe<Scalars['String']>
+    compliant?: Maybe<Scalars['String']>
+    status?: Maybe<Scalars['String']>
+    lastTransition?: Maybe<Scalars['String']>
+    name?: Maybe<Scalars['String']>
+    kind?: Maybe<Scalars['String']>
+    validity?: Maybe<Scalars['String']>
+    raw?: Maybe<Scalars['JSON']>
+}
+
+export type PolicyRules = {
+    apiGroups?: Maybe<Array<Maybe<Scalars['String']>>>
+    complianceType?: Maybe<Scalars['String']>
+    resources?: Maybe<Array<Maybe<Scalars['String']>>>
+    ruleUID?: Maybe<Scalars['String']>
+    templateType?: Maybe<Scalars['String']>
+    verbs?: Maybe<Array<Maybe<Scalars['String']>>>
+}
+
+export type Violations = {
+    cluster?: Maybe<Scalars['String']>
+    message?: Maybe<Scalars['String']>
+    name?: Maybe<Scalars['String']>
+    reason?: Maybe<Scalars['String']>
+    selector?: Maybe<Scalars['JSON']>
+    status?: Maybe<Scalars['String']>
+}
+
 export type Filters = {
     clusterLabels?: Maybe<Array<Maybe<FilterItem>>>
     clusterNames?: Maybe<Array<Maybe<FilterItem>>>
@@ -281,123 +311,6 @@ export type Occurrence = {
     securityClassification?: Maybe<Scalars['JSON']>
 }
 
-export type Namespace = K8sObject & {
-    cluster?: Maybe<Scalars['String']>
-    metadata?: Maybe<Metadata>
-    status?: Maybe<Scalars['String']>
-}
-
-export type NodeResources = {
-    cpu?: Maybe<Scalars['String']>
-    memory?: Maybe<Scalars['String']>
-}
-
-export type Node = {
-    capacity?: Maybe<NodeResources>
-    cluster?: Maybe<Cluster>
-    name?: Maybe<Scalars['String']>
-    labels?: Maybe<Scalars['JSON']>
-    roles?: Maybe<Array<Maybe<Scalars['String']>>>
-    status?: Maybe<Scalars['String']>
-}
-
-export type Pod = K8sObject & {
-    cluster?: Maybe<Cluster>
-    containers?: Maybe<Array<Maybe<Container>>>
-    hostIP?: Maybe<Scalars['String']>
-    images?: Maybe<Array<Maybe<Scalars['String']>>>
-    metadata?: Maybe<Metadata>
-    owners?: Maybe<Array<Maybe<Owner>>>
-    podIP?: Maybe<Scalars['String']>
-    restarts?: Maybe<Scalars['Int']>
-    startedAt?: Maybe<Scalars['String']>
-    status?: Maybe<Scalars['String']>
-}
-
-export type Owner = {
-    controller?: Maybe<Scalars['Boolean']>
-    kind?: Maybe<Scalars['String']>
-    name?: Maybe<Scalars['String']>
-    uid?: Maybe<Scalars['String']>
-}
-
-export type Container = {
-    image?: Maybe<Scalars['String']>
-    imagePullPolicy?: Maybe<Scalars['String']>
-    name?: Maybe<Scalars['String']>
-}
-
-export type Policy = K8sObject & {
-    detail?: Maybe<PolicyDetail>
-    enforcement?: Maybe<Scalars['String']>
-    metadata?: Maybe<Metadata>
-    rules?: Maybe<Array<Maybe<PolicyRules>>>
-    status?: Maybe<Scalars['String']>
-    roleTemplates?: Maybe<Array<Maybe<PolicyTemplates>>>
-    roleBindingTemplates?: Maybe<Array<Maybe<PolicyTemplates>>>
-    objectTemplates?: Maybe<Array<Maybe<PolicyTemplates>>>
-    violations?: Maybe<Array<Maybe<Violations>>>
-    raw?: Maybe<Scalars['JSON']>
-    message?: Maybe<Scalars['String']>
-    cluster?: Maybe<Scalars['String']>
-}
-
-export type PolicyDetail = {
-    exclude_namespace?: Maybe<Array<Maybe<Scalars['String']>>>
-    include_namespace?: Maybe<Array<Maybe<Scalars['String']>>>
-}
-
-export type PolicyTemplates = {
-    apiVersion?: Maybe<Scalars['String']>
-    complianceType?: Maybe<Scalars['String']>
-    compliant?: Maybe<Scalars['String']>
-    status?: Maybe<Scalars['String']>
-    lastTransition?: Maybe<Scalars['String']>
-    name?: Maybe<Scalars['String']>
-    kind?: Maybe<Scalars['String']>
-    validity?: Maybe<Scalars['String']>
-    raw?: Maybe<Scalars['JSON']>
-}
-
-export type PolicyRules = {
-    apiGroups?: Maybe<Array<Maybe<Scalars['String']>>>
-    complianceType?: Maybe<Scalars['String']>
-    resources?: Maybe<Array<Maybe<Scalars['String']>>>
-    ruleUID?: Maybe<Scalars['String']>
-    templateType?: Maybe<Scalars['String']>
-    verbs?: Maybe<Array<Maybe<Scalars['String']>>>
-}
-
-export type Violations = {
-    cluster?: Maybe<Scalars['String']>
-    message?: Maybe<Scalars['String']>
-    name?: Maybe<Scalars['String']>
-    reason?: Maybe<Scalars['String']>
-    selector?: Maybe<Scalars['JSON']>
-    status?: Maybe<Scalars['String']>
-}
-
-export type PVs = K8sObject & {
-    accessModes?: Maybe<Array<Maybe<Scalars['String']>>>
-    capacity?: Maybe<Scalars['String']>
-    claim?: Maybe<Scalars['String']>
-    claimRef?: Maybe<Scalars['JSON']>
-    cluster?: Maybe<Cluster>
-    metadata?: Maybe<Metadata>
-    reclaimPolicy?: Maybe<Scalars['String']>
-    status?: Maybe<Scalars['String']>
-    type?: Maybe<Scalars['String']>
-}
-
-export type PVsClaims = K8sObject & {
-    accessModes?: Maybe<Array<Maybe<Scalars['String']>>>
-    cluster?: Maybe<Cluster>
-    metadata?: Maybe<Metadata>
-    persistentVolume?: Maybe<Scalars['String']>
-    requests?: Maybe<Scalars['String']>
-    status?: Maybe<Scalars['String']>
-}
-
 export type Query = {
     application?: Maybe<Application>
     channels?: Maybe<Array<Maybe<Channel>>>
@@ -410,9 +323,6 @@ export type Query = {
     bareMetalAsset?: Maybe<Array<Maybe<BareMetalAsset>>>
     bareMetalAssets?: Maybe<Array<Maybe<BareMetalAsset>>>
     bareMetalAssetSubresources?: Maybe<BareMetalAssetSubresources>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    nodes?: Maybe<Array<Maybe<Node>>>
-    node?: Maybe<Array<Maybe<Node>>>
     /** @deprecated Compliances are deprecated from OCM. Use policies instead. */
     compliances?: Maybe<Array<Maybe<Compliance>>>
     occurrences?: Maybe<Array<Maybe<Occurrence>>>
@@ -423,7 +333,6 @@ export type Query = {
     overview?: Maybe<Overview>
     placementPolicies?: Maybe<Array<Maybe<PlacementPolicy>>>
     placementrules?: Maybe<Array<Maybe<PlacementRule>>>
-    policies?: Maybe<Array<Maybe<Policy>>>
     secrets?: Maybe<Array<Maybe<Secret>>>
     subscriptions?: Maybe<Array<Maybe<Subscription>>>
     subscriptionsForCluster?: Maybe<Array<Maybe<Subscription>>>
@@ -436,16 +345,6 @@ export type Query = {
     resourceTypes?: Maybe<Array<Maybe<Scalars['String']>>>
     topology?: Maybe<Topology>
     getAutomatedImportStatus?: Maybe<Scalars['JSON']>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    namespaces?: Maybe<Array<Maybe<Namespace>>>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    pod?: Maybe<Array<Maybe<Pod>>>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    pods?: Maybe<Array<Maybe<Pod>>>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    pvs?: Maybe<Array<Maybe<PVs>>>
-    /** @deprecated Use search, search has been moved to search-api. Will remove this query in 4.1 */
-    pvsClaims?: Maybe<Array<Maybe<PVsClaims>>>
 }
 
 export type QueryApplicationArgs = {
@@ -500,11 +399,6 @@ export type QueryBareMetalAssetSubresourcesArgs = {
     namespace?: Maybe<Scalars['String']>
 }
 
-export type QueryNodeArgs = {
-    namespace?: Maybe<Scalars['String']>
-    name?: Maybe<Scalars['String']>
-}
-
 export type QueryCompliancesArgs = {
     name?: Maybe<Scalars['String']>
     namespace?: Maybe<Scalars['String']>
@@ -516,6 +410,7 @@ export type QueryConnectionDetailsArgs = {
 }
 
 export type QueryGetResourceArgs = {
+    apiVersion?: Maybe<Scalars['String']>
     kind?: Maybe<Scalars['String']>
     name?: Maybe<Scalars['String']>
     namespace?: Maybe<Scalars['String']>
@@ -545,12 +440,6 @@ export type QueryPlacementrulesArgs = {
     namespace?: Maybe<Scalars['String']>
 }
 
-export type QueryPoliciesArgs = {
-    name?: Maybe<Scalars['String']>
-    namespace?: Maybe<Scalars['String']>
-    clusterName?: Maybe<Scalars['String']>
-}
-
 export type QuerySecretsArgs = {
     namespace?: Maybe<Scalars['String']>
 }
@@ -575,7 +464,8 @@ export type QueryUpdateResourceArgs = {
 }
 
 export type QueryUserAccessArgs = {
-    resource: Scalars['String']
+    resource?: Maybe<Scalars['String']>
+    kind?: Maybe<Scalars['String']>
     action: Scalars['String']
     namespace?: Maybe<Scalars['String']>
     apiGroup?: Maybe<Scalars['String']>
@@ -602,12 +492,6 @@ export type QueryTopologyArgs = {
 export type QueryGetAutomatedImportStatusArgs = {
     namespace?: Maybe<Scalars['String']>
     name?: Maybe<Scalars['String']>
-}
-
-export type QueryPodArgs = {
-    name?: Maybe<Scalars['String']>
-    namespace?: Maybe<Scalars['String']>
-    clusterName?: Maybe<Scalars['String']>
 }
 
 export type Mutation = {
@@ -679,6 +563,8 @@ export type MutationEditCloudConnectionArgs = {
 
 export type MutationUpdateResourceArgs = {
     resourceType: Scalars['String']
+    apiVersion?: Maybe<Scalars['String']>
+    kind?: Maybe<Scalars['String']>
     namespace: Scalars['String']
     name: Scalars['String']
     body?: Maybe<Scalars['JSON']>
@@ -688,6 +574,8 @@ export type MutationUpdateResourceArgs = {
 
 export type MutationUpdateResourceLabelsArgs = {
     resourceType: Scalars['String']
+    apiVersion?: Maybe<Scalars['String']>
+    kind?: Maybe<Scalars['String']>
     namespace: Scalars['String']
     name: Scalars['String']
     body?: Maybe<Scalars['JSON']>
@@ -707,6 +595,7 @@ export type MutationDeleteHelmArgs = {
 
 export type MutationDeleteResourceArgs = {
     selfLink?: Maybe<Scalars['String']>
+    apiVersion?: Maybe<Scalars['String']>
     name?: Maybe<Scalars['String']>
     namespace?: Maybe<Scalars['String']>
     cluster?: Maybe<Scalars['String']>
@@ -894,11 +783,14 @@ export enum CacheControlScope {
 }
 
 export type GetResourceQueryVariables = Exact<{
+    apiVersion?: Maybe<Scalars['String']>
     kind?: Maybe<Scalars['String']>
     name?: Maybe<Scalars['String']>
     namespace?: Maybe<Scalars['String']>
     cluster?: Maybe<Scalars['String']>
     selfLink?: Maybe<Scalars['String']>
+    updateInterval?: Maybe<Scalars['Int']>
+    deleteAfterUse?: Maybe<Scalars['Boolean']>
 }>
 
 export type GetResourceQuery = Pick<Query, 'getResource'>
@@ -916,6 +808,7 @@ export type UpdateResourceQuery = Pick<Query, 'updateResource'>
 
 export type DeleteResourceMutationVariables = Exact<{
     selfLink?: Maybe<Scalars['String']>
+    apiVersion?: Maybe<Scalars['String']>
     name?: Maybe<Scalars['String']>
     namespace?: Maybe<Scalars['String']>
     cluster?: Maybe<Scalars['String']>
@@ -979,8 +872,26 @@ export type GetOverviewQuery = {
 }
 
 export const GetResourceDocument = gql`
-    query getResource($kind: String, $name: String, $namespace: String, $cluster: String, $selfLink: String) {
-        getResource(kind: $kind, name: $name, namespace: $namespace, cluster: $cluster, selfLink: $selfLink)
+    query getResource(
+        $apiVersion: String
+        $kind: String
+        $name: String
+        $namespace: String
+        $cluster: String
+        $selfLink: String
+        $updateInterval: Int
+        $deleteAfterUse: Boolean
+    ) {
+        getResource(
+            apiVersion: $apiVersion
+            kind: $kind
+            name: $name
+            namespace: $namespace
+            cluster: $cluster
+            selfLink: $selfLink
+            updateInterval: $updateInterval
+            deleteAfterUse: $deleteAfterUse
+        )
     }
 `
 
@@ -996,11 +907,14 @@ export const GetResourceDocument = gql`
  * @example
  * const { data, loading, error } = useGetResourceQuery({
  *   variables: {
+ *      apiVersion: // value for 'apiVersion'
  *      kind: // value for 'kind'
  *      name: // value for 'name'
  *      namespace: // value for 'namespace'
  *      cluster: // value for 'cluster'
  *      selfLink: // value for 'selfLink'
+ *      updateInterval: // value for 'updateInterval'
+ *      deleteAfterUse: // value for 'deleteAfterUse'
  *   },
  * });
  */
@@ -1074,6 +988,7 @@ export type UpdateResourceQueryResult = Apollo.QueryResult<UpdateResourceQuery, 
 export const DeleteResourceDocument = gql`
     mutation deleteResource(
         $selfLink: String
+        $apiVersion: String
         $name: String
         $namespace: String
         $cluster: String
@@ -1082,6 +997,7 @@ export const DeleteResourceDocument = gql`
     ) {
         deleteResource(
             selfLink: $selfLink
+            apiVersion: $apiVersion
             name: $name
             namespace: $namespace
             cluster: $cluster
@@ -1106,6 +1022,7 @@ export type DeleteResourceMutationFn = Apollo.MutationFunction<DeleteResourceMut
  * const [deleteResourceMutation, { data, loading, error }] = useDeleteResourceMutation({
  *   variables: {
  *      selfLink: // value for 'selfLink'
+ *      apiVersion: // value for 'apiVersion'
  *      name: // value for 'name'
  *      namespace: // value for 'namespace'
  *      cluster: // value for 'cluster'

--- a/frontend/src/console-sdk/consoleQueries.graphql
+++ b/frontend/src/console-sdk/consoleQueries.graphql
@@ -1,13 +1,13 @@
-query getResource($kind: String, $name: String, $namespace: String, $cluster: String, $selfLink: String) {
-    getResource(kind: $kind, name: $name, namespace: $namespace, cluster: $cluster, selfLink: $selfLink)
+query getResource($apiVersion: String, $kind: String, $name: String, $namespace: String, $cluster: String, $selfLink: String, $updateInterval: Int, $deleteAfterUse: Boolean) {
+    getResource(apiVersion: $apiVersion, kind: $kind, name: $name, namespace: $namespace, cluster: $cluster, selfLink: $selfLink, updateInterval: $updateInterval, deleteAfterUse: $deleteAfterUse)
 }
 
 query updateResource($selfLink: String, $namespace: String, $kind: String, $name: String, $body: JSON, $cluster: String){
     updateResource(selfLink: $selfLink, namespace: $namespace, kind: $kind, name: $name, body: $body, cluster: $cluster)
 }
 
-mutation deleteResource($selfLink: String, $name: String, $namespace: String, $cluster: String, $kind: String, $childResources: JSON) {
-    deleteResource(selfLink: $selfLink, name: $name, namespace: $namespace, cluster: $cluster, kind: $kind, childResources: $childResources)
+mutation deleteResource($selfLink: String, $apiVersion: String, $name: String, $namespace: String, $cluster: String, $kind: String, $childResources: JSON) {
+    deleteResource(selfLink: $selfLink, apiVersion: $apiVersion, name: $name, namespace: $namespace, cluster: $cluster, kind: $kind, childResources: $childResources)
 }
 
 query userAccess($resource: String!, $action: String!, $namespace: String, $name: String, $apiGroup: String){

--- a/frontend/src/routes/DetailsPage/DetailsPage.test.tsx
+++ b/frontend/src/routes/DetailsPage/DetailsPage.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { Router } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { wait } from '../../lib/test-helper'
+import DetailsPage from './DetailsPage'
+import { GetResourceDocument } from '../../console-sdk/console-sdk'
+
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom')
+    return {
+        __esModule: true,
+        ...originalModule,
+        useLocation: () => ({
+            pathname: '/resources',
+            search: '?cluster=testCluster&kind=pods&apiversion=apps/v1&namespace=testNamespace&name=testPod',
+        }),
+        useHistory: () => ({
+            push: jest.fn(),
+        }),
+    }
+})
+Object.defineProperty(window, 'location', {
+    value: {
+        pathname: '/resources',
+        search: '?cluster=testCluster&kind=pods&apiversion=apps/v1&namespace=testNamespace&name=testPod',
+    },
+})
+jest.mock('./YAMLPage', () => {
+    // TODO replace with actual YAML Page when Monaco editor is imported correctly
+    return function YAMLPage() {
+        return <div />
+    }
+})
+
+describe('DetailsPage', () => {
+    it('should render details page correctly', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: GetResourceDocument,
+                    variables: {
+                        apiVersion: 'apps/v1',
+                        kind: 'pods',
+                        name: 'testPod',
+                        namespace: 'testNamespace',
+                        cluster: 'testCluster',
+                    },
+                },
+                result: {
+                    data: {
+                        getResource: {
+                            kind: 'Pod',
+                            apiVersion: 'apps/v1',
+                            metadata: {
+                                name: 'testPod',
+                                generateName: 'testPod-',
+                                namespace: 'testNamespace',
+                                resourceVersion: '33553',
+                                creationTimestamp: '2021-01-01T00:00:00Z',
+                                labels: {
+                                    label: 'testLabel',
+                                },
+                            },
+                            spec: {
+                                replicas: 1,
+                                template: {
+                                    metadata: {
+                                        creationTimestamp: null,
+                                        labels: {
+                                            label: 'testContainer',
+                                        },
+                                    },
+                                    spec: {
+                                        containers: [
+                                            {
+                                                name: 'testContainer',
+                                                image: 'testImage',
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            status: {
+                                replicas: 1,
+                                readyReplicas: 1,
+                                availableReplicas: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+
+        render(
+            <Router history={createBrowserHistory()}>
+                <MockedProvider mocks={mocks}>
+                    <DetailsPage />
+                </MockedProvider>
+            </Router>
+        )
+        // Test the loading state while apollo query finishes
+        // expect(screen.getByText('Loading')).toBeInTheDocument()
+        // This wait pauses till apollo query is returning data
+        await wait()
+        // Test that the component has rendered correctly with data
+        await waitFor(() => expect(screen.queryByText('testPod')).toBeTruthy())
+    })
+})

--- a/frontend/src/routes/DetailsPage/YAMLPage.tsx
+++ b/frontend/src/routes/DetailsPage/YAMLPage.tsx
@@ -68,14 +68,13 @@ export default function YAMLPage(props: {
     resource: Pick<Query, 'getResource'> | undefined
     loading: boolean
     error: ApolloError | undefined
-    selfLink: string
     name: string
     namespace: string
     cluster: string
     kind: string
-    api: string
+    apiversion: string
 }) {
-    const { resource, loading, error, selfLink, name, namespace, cluster, kind, api } = props
+    const { resource, loading, error, name, namespace, cluster, kind, apiversion } = props
     const [editMode, setEditMode] = useState<boolean>(false)
     const [userCanEdit, setUserCanEdit] = useState<boolean | undefined>(undefined)
     const [editedResourceYaml, setEditedResourceYaml] = useState<string>('')
@@ -101,7 +100,7 @@ export default function YAMLPage(props: {
             action: 'update',
             namespace,
             name,
-            apiGroup: api,
+            apiGroup: apiversion,
         },
     })
 
@@ -175,11 +174,10 @@ export default function YAMLPage(props: {
                             onClick={() => {
                                 updateResource({
                                     variables: {
-                                        body: jsYaml.loadAll(editedResourceYaml)[0],
-                                        selfLink,
                                         namespace,
                                         kind,
                                         name,
+                                        body: jsYaml.loadAll(editedResourceYaml)[0],
                                         cluster,
                                     },
                                 })

--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -6,7 +6,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -56,7 +57,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -111,7 +113,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -166,7 +169,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -236,7 +240,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -281,7 +286,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -346,7 +352,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -416,7 +423,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -466,7 +474,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -531,7 +540,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -576,7 +586,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -641,7 +652,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -701,7 +713,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -746,7 +759,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -806,7 +820,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -881,7 +896,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -946,7 +962,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -996,7 +1013,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1046,7 +1064,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1096,7 +1115,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1161,7 +1181,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1221,7 +1242,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1269,7 +1291,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1324,7 +1347,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1374,7 +1398,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1434,7 +1459,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1489,7 +1515,8 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/resources/testCluster/apigroup/cluster/name",
+          "pathname": "/resources",
+          "search": "?cluster=testCluster&kind=pod&namespace=testNamespace&name=testName",
         }
       }
     >
@@ -1578,7 +1605,8 @@ exports[`Correctly returns createDetailsLink - Default 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/resources/testCluster/self/link",
+      "pathname": "/resources",
+      "search": "?cluster=testCluster&kind=pod&namespace=testPodNamespace&name=testPodName",
     }
   }
 >
@@ -1598,7 +1626,8 @@ exports[`Correctly returns createDetailsLink - Managed-Policy 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/resources/testCluster/self/link",
+      "pathname": "/resources",
+      "search": "?cluster=testCluster&kind=policy&namespace=testPolicyNamespace&name=testPolicyName",
     }
   }
 >
@@ -1610,7 +1639,8 @@ exports[`Correctly returns createDetailsLink - NON-Application 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/resources/testCluster/self/link",
+      "pathname": "/resources",
+      "search": "?cluster=testCluster&kind=application&namespace=testApplicationNamespace&name=testApplicationName",
     }
   }
 >
@@ -1652,3 +1682,9 @@ exports[`Correctly returns label components 1`] = `
   }
 />
 `;
+
+exports[`Correctly returns url search params with 0 params 1`] = `"?cluster=testCluster"`;
+
+exports[`Correctly returns url search params with all params & apigroup 1`] = `"?cluster=testCluster&kind=pods&apiversion=v1&namespace=testNamespace&name=testName"`;
+
+exports[`Correctly returns url search params with all params without apigroup 1`] = `"?cluster=testCluster&kind=pods&apiversion=apps/v1&namespace=testNamespace&name=testName"`;

--- a/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.tsx
+++ b/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.tsx
@@ -33,8 +33,7 @@ export const DeleteResourceModal = (props: any) => {
     const [deleteResourceMutation, deleteResourceResults] = useDeleteResourceMutation({ client: consoleClient })
     let apiGroup = ''
     if (resource) {
-        const kind = resource.selfLink.split('/')
-        apiGroup = kind[1] === 'apis' ? kind[2] : ''
+        apiGroup = resource.apigroup ? `${resource.apigroup}/${resource.apiversion}` : resource.apiversion
     }
     const userAccessResponse = useUserAccessQuery({
         skip: !resource,
@@ -51,7 +50,7 @@ export const DeleteResourceModal = (props: any) => {
     function deleteResourceFn() {
         deleteResourceMutation({
             variables: {
-                selfLink: resource.selfLink,
+                apiVersion: apiGroup,
                 name: resource.name,
                 namespace: resource.namespace,
                 cluster: resource.cluster,

--- a/frontend/src/routes/SearchPage/searchDefinitions.test.ts
+++ b/frontend/src/routes/SearchPage/searchDefinitions.test.ts
@@ -4,6 +4,7 @@ import searchDefinitions, {
     createDashboardLink,
     createExternalLink,
     formatLabels,
+    getUrlSearchParam,
 } from './searchDefinitions'
 
 test('Correctly returns formatSearchbarSuggestions without T in timestamp', () => {
@@ -195,4 +196,38 @@ test('Correctly returns all resource definitions', () => {
         })
         expect(definition).toMatchSnapshot(`SearchDefinitions-${key}`)
     })
+})
+
+test('Correctly returns url search params with all params & apigroup', () => {
+    const item = {
+        cluster: 'testCluster',
+        kind: 'pods',
+        apiGroup: 'apps',
+        apiversion: 'v1',
+        name: 'testName',
+        namespace: 'testNamespace',
+    }
+    const result = getUrlSearchParam(item)
+    expect(result).toMatchSnapshot()
+})
+
+test('Correctly returns url search params with all params without apigroup', () => {
+    const item = {
+        cluster: 'testCluster',
+        kind: 'pods',
+        apigroup: 'apps',
+        apiversion: 'v1',
+        name: 'testName',
+        namespace: 'testNamespace',
+    }
+    const result = getUrlSearchParam(item)
+    expect(result).toMatchSnapshot()
+})
+
+test('Correctly returns url search params with 0 params', () => {
+    const item = {
+        cluster: 'testCluster',
+    }
+    const result = getUrlSearchParam(item)
+    expect(result).toMatchSnapshot()
 })

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1304,6 +1304,25 @@ export function getAge(item: any, key: string) {
     return '-'
 }
 
+export const getUrlSearchParam = (resource: any) => {
+    let searchString = `?cluster=${resource.cluster}`
+    if (resource.kind) {
+        searchString = `${searchString}&kind=${resource.kind}`
+    }
+    if (resource.apigroup && resource.apiversion) {
+        searchString = `${searchString}&apiversion=${resource.apigroup}/${resource.apiversion}`
+    } else if (!resource.apigroup && resource.apiversion) {
+        searchString = `${searchString}&apiversion=${resource.apiversion}`
+    }
+    if (resource.namespace) {
+        searchString = `${searchString}&namespace=${resource.namespace}`
+    }
+    if (resource.name) {
+        searchString = `${searchString}&name=${resource.name}`
+    }
+    return searchString
+}
+
 export function createDetailsLink(item: any) {
     switch (item.kind) {
         case 'cluster':
@@ -1313,16 +1332,43 @@ export function createDetailsLink(item: any) {
                 // only redirect to apps page if it is an ACM application
                 return <a href={`/multicloud/applications/${item.namespace}/${item.name}`}>{item.name}</a>
             }
-            return <Link to={{ pathname: `/resources/${item.cluster}${item.selfLink}` }}>{item.name}</Link>
+            return (
+                <Link
+                    to={{
+                        pathname: '/resources',
+                        search: getUrlSearchParam(item),
+                    }}
+                >
+                    {item.name}
+                </Link>
+            )
         case 'policy':
             // Redirects to the policy page if the policy is a hub cluster resource.
             // If the policy is not, it will redirect and just show the yaml.
             if (item._hubClusterResource && item.apigroup === 'policy.open-cluster-management.io') {
                 return <a href={`/multicloud/policies/all/${item.name}`}>{item.name}</a>
             }
-            return <Link to={{ pathname: `/resources/${item.cluster}${item.selfLink}` }}>{item.name}</Link>
+            return (
+                <Link
+                    to={{
+                        pathname: '/resources',
+                        search: getUrlSearchParam(item),
+                    }}
+                >
+                    {item.name}
+                </Link>
+            )
         default:
-            return <Link to={{ pathname: `/resources/${item.cluster}${item.selfLink}` }}>{item.name}</Link>
+            return (
+                <Link
+                    to={{
+                        pathname: '/resources',
+                        search: getUrlSearchParam(item),
+                    }}
+                >
+                    {item.name}
+                </Link>
+            )
     }
 }
 


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#8558 & open-cluster-management/backlog#8557

### Description of changes
- Fixed the routing to the details and logs pages
  - Details: `/resources?cluster=<cluster>&kind=<kind>&apiversion=<apiversion>&namespace=<namespace>&name=<name>`
  - Logs: `/resources/logs?cluster=<cluster>&kind=<kind>&apiversion=<apiversion>&namespace=<namespace>&name=<name>`

- Fixed the console-api queries that were dependent on selflink

FYI @KevinFCormier @ycao56 
