### PR TITLE
Disabled show all button for small amounts of related resources

### DIFF
--- a/frontend/src/routes/SearchPage/components/SearchResults.tsx
+++ b/frontend/src/routes/SearchPage/components/SearchResults.tsx
@@ -151,11 +151,7 @@ function RenderRelatedTiles(
         const relatedCounts = data.searchResult[0]!.related || []
         return (
             <PageSection>
-                <AcmExpandableWrapper
-                    maxHeight={'10rem'}
-                    withCount={true}
-                    expandable={relatedCounts.length > 2}
-                >
+                <AcmExpandableWrapper maxHeight={'10rem'} withCount={true} expandable={relatedCounts.length > 2}>
                     {relatedCounts.map((count) => {
                         return (
                             <AcmTile


### PR DESCRIPTION
### Description of changes
- Disabled `Show all(...)` button if there are only two or fewer results returned for related resources.

