### PR TITLE
Fix the filtering of search results post-delete resource

### DIFF
--- a/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.test.tsx
+++ b/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MockedProvider } from '@apollo/client/testing'
+import { GraphQLError } from 'graphql'
+import { wait } from '../../../../lib/test-helper'
+import { DeleteResourceModal } from './DeleteResourceModal'
+import { DeleteResourceDocument, UserAccessDocument } from '../../../../console-sdk/console-sdk'
+import {
+    SearchResultItemsDocument,
+    SearchResultRelatedCountDocument,
+    SearchResultRelatedItemsDocument,
+} from '../../../../search-sdk/search-sdk'
+
+describe('DeleteResourceModal', () => {
+    it('should call the delete resource mutation with a successful response', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: UserAccessDocument,
+                    variables: {
+                        resource: 'pod',
+                        action: 'delete',
+                        namespace: 'testNamespace',
+                        name: 'testPod',
+                        apiGroup: 'v1',
+                    },
+                },
+                result: {
+                    data: {
+                        userAccess: {
+                            allowed: true,
+                            reason: 'RBAC: allowed by ...',
+                            namespace: 'testNamespace',
+                            verb: 'delete',
+                            group: 'v1',
+                            version: '*',
+                            resource: 'pod',
+                            name: 'testPod',
+                        },
+                    },
+                },
+            },
+            {
+                request: {
+                    query: DeleteResourceDocument,
+                    variables: {
+                        apiVersion: 'v1',
+                        name: 'testPod',
+                        namespace: 'testNamespace',
+                        cluster: 'testCluster',
+                        kind: 'pod',
+                    },
+                },
+                result: {
+                    data: {
+                        deleteResource: {
+                            apiVersion: 'v1',
+                            kind: 'pod',
+                            metadata: {
+                                name: 'testPod',
+                                namespace: 'testNamespace',
+                            },
+                        },
+                    },
+                },
+            },
+            {
+                request: {
+                    query: SearchResultItemsDocument,
+                    variables: {
+                        input: [
+                            {
+                                keywords: [],
+                                filters: [
+                                    {
+                                        property: 'kind',
+                                        values: ['pod'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    fetchPolicy: 'cache-first',
+                },
+                result: {
+                    data: {
+                        searchResult: [
+                            {
+                                items: [
+                                    {
+                                        apiversion: 'v1',
+                                        cluster: 'testCluster',
+                                        container: 'installer',
+                                        created: '2021-01-04T14:53:52Z',
+                                        hostIP: '10.0.128.203',
+                                        kind: 'pod',
+                                        name: 'testPod',
+                                        namespace: 'testNamespace',
+                                        podIP: '10.129.0.40',
+                                        restarts: 0,
+                                        startedAt: '2021-01-04T14:53:52Z',
+                                        status: 'Completed',
+                                        _uid: 'testing-search-results-pod',
+                                    },
+                                ],
+                                __typename: 'SearchResult',
+                            },
+                        ],
+                    },
+                },
+            },
+        ]
+        render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <DeleteResourceModal
+                    open={true}
+                    currentQuery={'kind:pod'}
+                    resource={{
+                        name: 'testPod',
+                        namespace: 'testNamespace',
+                        kind: 'pod',
+                        apiversion: 'v1',
+                        cluster: 'testCluster',
+                    }}
+                    close={() => {}}
+                />
+            </MockedProvider>
+        )
+
+        // wait for userAccess query to finish
+        await wait()
+
+        // find the button and simulate a click
+        const submitButton = screen.getByText('Delete')
+        expect(submitButton).toBeTruthy()
+        userEvent.click(submitButton)
+
+        await wait() // Test that the component has rendered correctly with an error
+        await waitFor(() => expect(screen.queryByTestId('delete-resource-error')).not.toBeInTheDocument())
+    })
+})

--- a/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.tsx
+++ b/frontend/src/routes/SearchPage/components/Modals/DeleteResourceModal.tsx
@@ -30,14 +30,16 @@ export const ClosedDeleteModalProps: IDeleteModalProps = {
 
 export const DeleteResourceModal = (props: any) => {
     const { open, close, resource, currentQuery, relatedResource } = props
-    const [deleteResourceMutation, deleteResourceResults] = useDeleteResourceMutation({ client: consoleClient })
+    const [deleteResourceMutation, deleteResourceResults] = useDeleteResourceMutation({
+        client: process.env.NODE_ENV === 'test' ? undefined : consoleClient,
+    })
     let apiGroup = ''
     if (resource) {
         apiGroup = resource.apigroup ? `${resource.apigroup}/${resource.apiversion}` : resource.apiversion
     }
     const userAccessResponse = useUserAccessQuery({
         skip: !resource,
-        client: consoleClient,
+        client: process.env.NODE_ENV === 'test' ? undefined : consoleClient,
         variables: {
             resource: resource?.kind,
             action: 'delete',
@@ -171,7 +173,7 @@ export const DeleteResourceModal = (props: any) => {
                                             {
                                                 __typename: 'SearchResult',
                                                 items: res.data.searchResult[0].items.filter((item: any) => {
-                                                    return item._uid !== resource._uid && item.name !== resource.name
+                                                    return item._uid !== resource._uid
                                                 }),
                                             },
                                         ],
@@ -210,7 +212,12 @@ export const DeleteResourceModal = (props: any) => {
                 ]}
             >
                 {userAccessResponse.error ? (
-                    <AcmAlert noClose={true} variant={'danger'} title={userAccessResponse.error} />
+                    <AcmAlert
+                        data-testid={'user-access-error'}
+                        noClose={true}
+                        variant={'danger'}
+                        title={userAccessResponse.error}
+                    />
                 ) : null}
                 {!userAccessResponse.loading && !userAccessResponse?.data?.userAccess.allowed ? (
                     <AcmAlert
@@ -220,7 +227,12 @@ export const DeleteResourceModal = (props: any) => {
                     />
                 ) : null}
                 {deleteResourceResults.error ? (
-                    <AcmAlert noClose={true} variant={'danger'} title={deleteResourceResults.error.message} />
+                    <AcmAlert
+                        data-testid={'delete-resource-error'}
+                        noClose={true}
+                        variant={'danger'}
+                        title={deleteResourceResults.error.message}
+                    />
                 ) : null}
                 <div
                     style={{ paddingTop: '1rem' }}


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#8946

### Description of changes
- After deleting a resource from search results table, we update the table items to remove the deleted resource. This PR fixes the filtering logic that removes the deleted resource from the table.

