### PR TITLE
Fix cluster search issue

### DIFF
--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Correctly returns CreateDashboardLink 1`] = `
   rel="noopener noreferrer"
   target="_blank"
 >
-  search.results.table.launch.health
+  Launch health view
 </a>
 `;
 
@@ -128,7 +128,7 @@ Array [
       rel="noopener noreferrer"
       target="_blank"
     >
-      search.results.table.launch.health
+      Launch health view
     </a>,
     "header": "Dashboard",
     "sort": "dashboard",

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import moment from 'moment'
 import { AcmLabels } from '@open-cluster-management/ui-components'
-import { useTranslation } from 'react-i18next'
 
 // eslint-disable-next-line import/no-anonymous-default-export
 const searchDefinitions: any = {
@@ -1383,11 +1382,11 @@ export function CreateDetailsLink(item: any) {
 }
 
 export function CreateDashboardLink(item: any) {
-    const { t } = useTranslation(['search'])
     if (item.dashboard !== null && item.dashboard !== '') {
         return (
             <a target="_blank" rel="noopener noreferrer" href={item.dashboard}>
-                {t('search.results.table.launch.health')}
+                {/* TODO Not translating - caused issue: https://github.com/open-cluster-management/backlog/issues/9184 */}
+                {'Launch health view'}
             </a>
         )
     }
@@ -1398,6 +1397,7 @@ export function CreateExternalLink(item: any) {
     if (item.consoleURL) {
         return (
             <a target="_blank" rel="noopener noreferrer" href={`${item.consoleURL}`}>
+                {/* TODO Not translating - caused issue: https://github.com/open-cluster-management/backlog/issues/9184 */}
                 {'Launch'}
             </a>
         )


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9184

### Description of changes
- Removing translation hook for table cell transform
- Fixes the issue where search page breaks on `kind:cluster` search

