### PR TITLE
Add OpenStack provider to Overview page

### DIFF
--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -42,6 +42,8 @@ export function mapProviderFromLabel(provider: string): Provider {
             return Provider.redhatcloud
         case 'VMware':
             return Provider.vmware
+        case 'OpenStack':
+            return Provider.openstack
         default:
             return Provider.other
     }


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9889
https://github.com/open-cluster-management/backlog/issues/8879

### Description of changes
- Added OpenStack provider to the overview page

